### PR TITLE
Disable sandboxing for ownKeePass

### DIFF
--- a/Sailfish/harbour-ownkeepass.desktop
+++ b/Sailfish/harbour-ownkeepass.desktop
@@ -5,3 +5,6 @@ Icon=harbour-ownkeepass
 Exec=harbour-ownkeepass
 Name=ownKeepass
 Comment=ownKeepass Password Safe
+
+[X-Sailjail]
+Sandboxing=Disabled


### PR DESCRIPTION
Disabling Sailjail sandboxing allows ownKeePass to access key files and databases stored in directories other than the few standard ones Sailfish allows to access otherwise.